### PR TITLE
fix: delete proof for indexing purposes

### DIFF
--- a/indexer.go
+++ b/indexer.go
@@ -43,7 +43,6 @@ type Transaction struct {
 	MessageType     string
 	Height          int
 	Index           int
-	Proof           *provider.TransactionProof
 	StdTx           *provider.StdTx
 	TxResult        *provider.TxResult
 	Tx              string
@@ -91,7 +90,6 @@ func convertProviderTransactionToTransaction(providerTransaction *provider.Trans
 		MessageType:     stdTx.Msg.Type,
 		Height:          providerTransaction.Height,
 		Index:           providerTransaction.Index,
-		Proof:           providerTransaction.Proof,
 		StdTx:           stdTx,
 		TxResult:        providerTransaction.TxResult,
 		Tx:              providerTransaction.Tx,
@@ -108,8 +106,8 @@ func (i *Indexer) IndexBlockTransactions(blockHeight int) error {
 
 	for {
 		blockTransactionsOutput, err := i.provider.GetBlockTransactions(blockHeight, &provider.GetBlockTransactionsOptions{
-			Prove: true,
-			Page:  currentPage,
+			Page:    currentPage,
+			PerPage: 10000,
 		})
 		if err != nil {
 			return err

--- a/postgres-driver/jsonb_parser.go
+++ b/postgres-driver/jsonb_parser.go
@@ -35,28 +35,6 @@ func (r *txResult) Scan(value any) error {
 	return json.Unmarshal(b, &r)
 }
 
-// proof is a wrapper for provider.TransactionProof to implement interfaces for JSONB parsing
-type proof struct {
-	*provider.TransactionProof
-}
-
-// Make the proof struct implement the driver.Valuer interface. This method
-// simply returns the JSON-encoded representation of the struct.
-func (p *proof) Value() (driver.Value, error) {
-	return json.Marshal(p)
-}
-
-// Make the proof struct implement the sql.Scanner interface. This method
-// simply decodes a JSON-encoded value into the struct fields.
-func (p *proof) Scan(value any) error {
-	b, ok := value.([]byte)
-	if !ok {
-		return ErrByteTypeAssertionFailed
-	}
-
-	return json.Unmarshal(b, &p)
-}
-
 // stdTx is a wrapper for provider.StdTx to implement interfaces for JSONB parsing
 type stdTx struct {
 	*provider.StdTx

--- a/postgres-driver/postgres_driver.go
+++ b/postgres-driver/postgres_driver.go
@@ -11,8 +11,8 @@ import (
 
 const (
 	insertTransactionsScript = `
-	INSERT into transactions (hash, from_address, to_address, app_pub_key, blockchains, message_type, height, index, proof, stdtx, tx_result, tx, entropy, fee, fee_denomination)
-	VALUES (:hash, :from_address, :to_address, :app_pub_key, :blockchains, :message_type, :height, :index, :proof, :stdtx, :tx_result, :tx, :entropy, :fee, :fee_denomination)`
+	INSERT into transactions (hash, from_address, to_address, app_pub_key, blockchains, message_type, height, index, stdtx, tx_result, tx, entropy, fee, fee_denomination)
+	VALUES (:hash, :from_address, :to_address, :app_pub_key, :blockchains, :message_type, :height, :index, :stdtx, :tx_result, :tx, :entropy, :fee, :fee_denomination)`
 	insertBlockScript = `
 	INSERT into blocks (hash, height, time, proposer_address, tx_count, relay_count)
 	VALUES (:hash, :height, :time, :proposer_address, :tx_count, :relay_count)`
@@ -58,7 +58,6 @@ type dbTransaction struct {
 	MessageType     string         `db:"message_type"`
 	Height          int            `db:"height"`
 	Index           int            `db:"index"`
-	Proof           *proof         `db:"proof"`
 	StdTx           *stdTx         `db:"stdtx"`
 	TxResult        *txResult      `db:"tx_result"`
 	Tx              string         `db:"tx"`
@@ -77,7 +76,6 @@ func (t *dbTransaction) toIndexerTransaction() *indexer.Transaction {
 		MessageType:     t.MessageType,
 		Height:          t.Height,
 		Index:           t.Index,
-		Proof:           t.Proof.TransactionProof,
 		StdTx:           t.StdTx.StdTx,
 		TxResult:        t.TxResult.TxResult,
 		Tx:              t.Tx,
@@ -97,7 +95,6 @@ func convertIndexerTransactionToDBTransaction(indexerTransaction *indexer.Transa
 		MessageType:     indexerTransaction.MessageType,
 		Height:          indexerTransaction.Height,
 		Index:           indexerTransaction.Index,
-		Proof:           &proof{TransactionProof: indexerTransaction.Proof},
 		StdTx:           &stdTx{StdTx: indexerTransaction.StdTx},
 		TxResult:        &txResult{TxResult: indexerTransaction.TxResult},
 		Tx:              indexerTransaction.Tx,

--- a/postgres-driver/postgres_driver_test.go
+++ b/postgres-driver/postgres_driver_test.go
@@ -60,7 +60,7 @@ func TestPostgresDriver_WriteTransactions(t *testing.T) {
 	c.NoError(err)
 
 	mock.ExpectExec("INSERT into transactions").WithArgs("AF5BB3EAFF431E2E5E784D639825979FF20A779725BFE61D4521340F70C3996D0",
-		"addssd", "adasd", "adasdsfd", pq.StringArray([]string{"0021"}), "pos/Send", int64(0), int64(0), []uint8{123, 125}, encodedTestStdTx,
+		"addssd", "adasd", "adasdsfd", pq.StringArray([]string{"0021"}), "pos/Send", int64(0), int64(0), encodedTestStdTx,
 		[]uint8{123, 125}, "", int64(3223323), int64(10000), "upokt").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
@@ -85,7 +85,7 @@ func TestPostgresDriver_WriteTransactions(t *testing.T) {
 	c.NoError(err)
 
 	mock.ExpectExec("INSERT into transactions").WithArgs("AF5BB3EAFF431E2E5E784D639825979FF20A779725BFE61D4521340F70C3996D0",
-		"addssd", "adasd", "adasdsfd", pq.StringArray([]string{"0021"}), "pos/Send", int64(0), int64(0), []uint8{123, 125}, encodedTestStdTx,
+		"addssd", "adasd", "adasdsfd", pq.StringArray([]string{"0021"}), "pos/Send", int64(0), int64(0), encodedTestStdTx,
 		[]uint8{123, 125}, "", int64(3223323), int64(10000), "upokt").
 		WillReturnError(errors.New("dummy error"))
 
@@ -115,16 +115,9 @@ func TestPostgresDriver_ReadTransactions(t *testing.T) {
 	encodedTxResult, err := testTxResult.Value()
 	c.NoError(err)
 
-	testProof := &proof{
-		TransactionProof: &provider.TransactionProof{},
-	}
-
-	encodedTestProof, err := testProof.Value()
-	c.NoError(err)
-
-	rows := sqlmock.NewRows([]string{"id", "hash", "from_address", "to_address", "stdtx", "tx_result", "proof"}).
-		AddRow(1, "ABCD", "abcd", "dbcv", encodedTestStdTx, encodedTxResult, encodedTestProof).
-		AddRow(2, "ABFD", "abfd", "fbcv", encodedTestStdTx, encodedTxResult, encodedTestProof)
+	rows := sqlmock.NewRows([]string{"id", "hash", "from_address", "to_address", "stdtx", "tx_result"}).
+		AddRow(1, "ABCD", "abcd", "dbcv", encodedTestStdTx, encodedTxResult).
+		AddRow(2, "ABFD", "abfd", "fbcv", encodedTestStdTx, encodedTxResult)
 
 	mock.ExpectQuery("^SELECT (.+) FROM transactions$").WillReturnRows(rows)
 
@@ -163,15 +156,8 @@ func TestPostgresDriver_ReadTransaction(t *testing.T) {
 	encodedTxResult, err := testTxResult.Value()
 	c.NoError(err)
 
-	testProof := &proof{
-		TransactionProof: &provider.TransactionProof{},
-	}
-
-	encodedTestProof, err := testProof.Value()
-	c.NoError(err)
-
-	rows := sqlmock.NewRows([]string{"id", "hash", "from_address", "to_address", "stdtx", "tx_result", "proof"}).
-		AddRow(1, "ABCD", "abcd", "dbcv", encodedTestStdTx, encodedTxResult, encodedTestProof)
+	rows := sqlmock.NewRows([]string{"id", "hash", "from_address", "to_address", "stdtx", "tx_result"}).
+		AddRow(1, "ABCD", "abcd", "dbcv", encodedTestStdTx, encodedTxResult)
 
 	mock.ExpectQuery("^SELECT (.+) FROM transactions (.+)").WillReturnRows(rows)
 


### PR DESCRIPTION
Delete transaction proof of indexed values since it makes the core request really slow and it does not really bring value to the indexer service.