### PR TITLE
fix: sanitize core result before saving it

### DIFF
--- a/indexer.go
+++ b/indexer.go
@@ -1,10 +1,18 @@
 package indexer
 
 import (
+	"errors"
 	"strconv"
 	"time"
 
 	"github.com/pokt-foundation/pocket-go/provider"
+)
+
+var (
+	// ErrNoTransactionsToIndex error when there are no transactions to index
+	ErrNoTransactionsToIndex = errors.New("no transactions to index")
+	// ErrBlockHasNoHash error when block hash no hash
+	ErrBlockHasNoHash = errors.New("block to index has no hash")
 )
 
 // Provider interface of needed provider functions
@@ -122,6 +130,10 @@ func (i *Indexer) IndexBlockTransactions(blockHeight int) error {
 		currentPage++
 	}
 
+	if len(providerTxs) == 0 {
+		return ErrNoTransactionsToIndex
+	}
+
 	var transactions []*Transaction
 
 	for _, tx := range providerTxs {
@@ -151,6 +163,10 @@ func (i *Indexer) IndexBlock(blockHeight int) error {
 	blockOutput, err := i.provider.GetBlock(blockHeight)
 	if err != nil {
 		return err
+	}
+
+	if blockOutput.BlockID.Hash == "" {
+		return ErrBlockHasNoHash
 	}
 
 	err = i.writer.WriteBlock(convertProviderBlockToBlock(blockOutput))

--- a/indexer_test.go
+++ b/indexer_test.go
@@ -47,6 +47,12 @@ func TestIndexer_IndexBlockTransactions(t *testing.T) {
 	err := indexer.IndexBlockTransactions(30363)
 	c.Equal(provider.Err5xxOnConnection, err)
 
+	mock.AddMockedResponseFromFile(http.MethodPost, fmt.Sprintf("%s%s", "https://dummy.com", provider.QueryBlockTXsRoute),
+		http.StatusOK, "samples/query_block_txs_empty.json")
+
+	err = indexer.IndexBlockTransactions(30363)
+	c.Equal(ErrNoTransactionsToIndex, err)
+
 	mock.AddMultipleMockedResponses(http.MethodPost, fmt.Sprintf("%s%s", "https://dummy.com", provider.QueryBlockTXsRoute),
 		http.StatusOK, []string{
 			"samples/query_block_txs.json",
@@ -83,6 +89,12 @@ func TestIndexer_IndexBlock(t *testing.T) {
 
 	err := indexer.IndexBlock(30363)
 	c.Equal(provider.Err5xxOnConnection, err)
+
+	mock.AddMockedResponseFromFile(http.MethodPost, fmt.Sprintf("%s%s", "https://dummy.com", provider.QueryBlockRoute),
+		http.StatusOK, "samples/query_block_empty.json")
+
+	err = indexer.IndexBlock(30363)
+	c.Equal(ErrBlockHasNoHash, err)
 
 	mock.AddMockedResponseFromFile(http.MethodPost, fmt.Sprintf("%s%s", "https://dummy.com", provider.QueryBlockRoute),
 		http.StatusOK, "samples/query_block.json")

--- a/samples/query_block.json
+++ b/samples/query_block.json
@@ -79,5 +79,12 @@
           "block": "10"
         }
       }
-    }
+    },
+    "block_id": {
+      "hash": "DC6109DB96D2CBEB6507737A1496704F9BECA1DDB48BF975D1871361D211734C",
+      "parts": {
+          "hash": "674AB0AA1E32F18FF9338A31176491DEFE1617AA2336A1BE9DA5AE215FCF92DE",
+          "total": "1"
+      }
+  }
 }

--- a/samples/query_block_empty.json
+++ b/samples/query_block_empty.json
@@ -1,0 +1,7 @@
+{
+    "block": null,
+    "block_id": {
+      "hash": null,
+      "parts": null
+    }
+}


### PR DESCRIPTION
Ensure core result to send to database is correct before calling save database function