### PR TITLE
fix: remove relay count

### DIFF
--- a/indexer.go
+++ b/indexer.go
@@ -155,7 +155,6 @@ type Block struct {
 	Time            time.Time
 	ProposerAddress string
 	TXCount         int
-	RelayCount      int
 }
 
 // IndexBlock converts block details to a known structure and saves them
@@ -189,6 +188,5 @@ func convertProviderBlockToBlock(providerBlock *provider.GetBlockOutput) *Block 
 		Time:            blockHeader.Time,
 		ProposerAddress: blockHeader.ProposerAddress,
 		TXCount:         totalTxs,
-		RelayCount:      0, // TODO: add correct RelayCount
 	}
 }

--- a/postgres-driver/postgres_driver.go
+++ b/postgres-driver/postgres_driver.go
@@ -17,8 +17,8 @@ const (
 	INSERT into transactions (hash, from_address, to_address, app_pub_key, blockchains, message_type, height, index, stdtx, tx_result, tx, entropy, fee, fee_denomination)
 	VALUES (:hash, :from_address, :to_address, :app_pub_key, :blockchains, :message_type, :height, :index, :stdtx, :tx_result, :tx, :entropy, :fee, :fee_denomination)`
 	insertBlockScript = `
-	INSERT into blocks (hash, height, time, proposer_address, tx_count, relay_count)
-	VALUES (:hash, :height, :time, :proposer_address, :tx_count, :relay_count)`
+	INSERT into blocks (hash, height, time, proposer_address, tx_count)
+	VALUES (:hash, :height, :time, :proposer_address, :tx_count)`
 	selectTransactionsScript = `
 	DECLARE transactions_cursor CURSOR FOR SELECT * FROM transactions ORDER BY height DESC;
 	MOVE absolute %d from transactions_cursor;
@@ -285,7 +285,6 @@ type dbBlock struct {
 	Time            time.Time `db:"time"`
 	ProposerAddress string    `db:"proposer_address"`
 	TXCount         int       `db:"tx_count"`
-	RelayCount      int       `db:"relay_count"`
 }
 
 func (b *dbBlock) toIndexerBlock() *indexer.Block {
@@ -295,7 +294,6 @@ func (b *dbBlock) toIndexerBlock() *indexer.Block {
 		Time:            b.Time,
 		ProposerAddress: b.ProposerAddress,
 		TXCount:         b.TXCount,
-		RelayCount:      b.RelayCount,
 	}
 }
 
@@ -306,7 +304,6 @@ func convertIndexerBlockToDBBlock(indexerBlock *indexer.Block) *dbBlock {
 		Time:            indexerBlock.Time,
 		ProposerAddress: indexerBlock.ProposerAddress,
 		TXCount:         indexerBlock.TXCount,
-		RelayCount:      indexerBlock.RelayCount,
 	}
 }
 

--- a/postgres-driver/postgres_driver_test.go
+++ b/postgres-driver/postgres_driver_test.go
@@ -227,7 +227,7 @@ func TestPostgresDriver_WriteBlock(t *testing.T) {
 	defer db.Close()
 
 	mock.ExpectExec("INSERT into blocks").WithArgs("AF5BB3EAFF431E2E5E784D639825979FF20A779725BFE61D4521340F70C3996D0",
-		21, time.Date(1999, time.July, 21, 0, 0, 0, 0, time.Local), "A2143929B30CBC3E7A30C2DE06B385BCF874134B", 32, 21).
+		21, time.Date(1999, time.July, 21, 0, 0, 0, 0, time.Local), "A2143929B30CBC3E7A30C2DE06B385BCF874134B", 32).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	driver := NewPostgresDriverFromSQLDBInstance(db)
@@ -242,7 +242,7 @@ func TestPostgresDriver_WriteBlock(t *testing.T) {
 	c.NoError(err)
 
 	mock.ExpectExec("INSERT into blocks").WithArgs("AF5BB3EAFF431E2E5E784D639825979FF20A779725BFE61D4521340F70C3996D0",
-		21, time.Date(1999, time.July, 21, 0, 0, 0, 0, time.Local), "A2143929B30CBC3E7A30C2DE06B385BCF874134B", 32, 21).
+		21, time.Date(1999, time.July, 21, 0, 0, 0, 0, time.Local), "A2143929B30CBC3E7A30C2DE06B385BCF874134B", 32).
 		WillReturnError(errors.New("dummy error"))
 
 	err = driver.WriteBlock(&indexer.Block{

--- a/postgres-driver/postgres_driver_test.go
+++ b/postgres-driver/postgres_driver_test.go
@@ -238,7 +238,6 @@ func TestPostgresDriver_WriteBlock(t *testing.T) {
 		Time:            time.Date(1999, time.July, 21, 0, 0, 0, 0, time.Local),
 		ProposerAddress: "A2143929B30CBC3E7A30C2DE06B385BCF874134B",
 		TXCount:         32,
-		RelayCount:      21,
 	})
 	c.NoError(err)
 
@@ -252,7 +251,6 @@ func TestPostgresDriver_WriteBlock(t *testing.T) {
 		Time:            time.Date(1999, time.July, 21, 0, 0, 0, 0, time.Local),
 		ProposerAddress: "A2143929B30CBC3E7A30C2DE06B385BCF874134B",
 		TXCount:         32,
-		RelayCount:      21,
 	})
 	c.EqualError(err, "dummy error")
 }
@@ -265,9 +263,9 @@ func TestPostgresDriver_ReadBlocks(t *testing.T) {
 
 	defer db.Close()
 
-	rows := sqlmock.NewRows([]string{"id", "hash", "height", "time", "proposer_address", "tx_count", "relay_count"}).
-		AddRow(1, "ABCD", 21, time.Date(1999, time.July, 21, 0, 0, 0, 0, time.Local), "ABCD", 21, 21).
-		AddRow(2, "ABCD", 21, time.Date(1999, time.July, 21, 0, 0, 0, 0, time.Local), "ABCD", 21, 21)
+	rows := sqlmock.NewRows([]string{"id", "hash", "height", "time", "proposer_address", "tx_count"}).
+		AddRow(1, "ABCD", 21, time.Date(1999, time.July, 21, 0, 0, 0, 0, time.Local), "ABCD", 21).
+		AddRow(2, "ABCD", 21, time.Date(1999, time.July, 21, 0, 0, 0, 0, time.Local), "ABCD", 21)
 
 	mock.ExpectBegin()
 	mock.ExpectQuery(".*").WillReturnRows(rows)
@@ -296,8 +294,8 @@ func TestPostgresDriver_ReadBlock(t *testing.T) {
 
 	defer db.Close()
 
-	rows := sqlmock.NewRows([]string{"id", "hash", "height", "time", "proposer_address", "tx_count", "relay_count"}).
-		AddRow(1, "ABCD", 21, time.Date(1999, time.July, 21, 0, 0, 0, 0, time.Local), "ABCD", 21, 21)
+	rows := sqlmock.NewRows([]string{"id", "hash", "height", "time", "proposer_address", "tx_count"}).
+		AddRow(1, "ABCD", 21, time.Date(1999, time.July, 21, 0, 0, 0, 0, time.Local), "ABCD", 21)
 
 	mock.ExpectQuery("^SELECT (.+) FROM blocks (.+)").WillReturnRows(rows)
 


### PR DESCRIPTION
This removes the RelayCount field from the Block entity, as it requires more complex procedures and is not required for now.