### PR TITLE
feat: add missing queries and amount field

### DIFF
--- a/indexer.go
+++ b/indexer.go
@@ -57,10 +57,12 @@ type Transaction struct {
 	Entropy         int
 	Fee             int
 	FeeDenomination string
+	Amount          int
 }
 
 func convertProviderTransactionToTransaction(providerTransaction *provider.Transaction) *Transaction {
 	var fromAddress, toAddress string
+	var amount int
 	var blockChains []string
 
 	stdTx := providerTransaction.StdTx
@@ -75,6 +77,11 @@ func convertProviderTransactionToTransaction(providerTransaction *provider.Trans
 	rawToAddress, ok := msgValues["to_address"].(string)
 	if ok {
 		toAddress = rawToAddress
+	}
+
+	rawAmount, ok := msgValues["amount"].(string)
+	if ok {
+		amount, _ = strconv.Atoi(rawAmount)
 	}
 
 	rawBlockChains, ok := msgValues["chains"].([]any)
@@ -104,6 +111,7 @@ func convertProviderTransactionToTransaction(providerTransaction *provider.Trans
 		Entropy:         int(stdTx.Entropy),
 		Fee:             fee,
 		FeeDenomination: feeStruct.Denom,
+		Amount:          amount,
 	}
 }
 

--- a/postgres-driver/postgres_driver_test.go
+++ b/postgres-driver/postgres_driver_test.go
@@ -32,6 +32,7 @@ func TestPostgresDriver_WriteTransactions(t *testing.T) {
 			Type: "pos/Send",
 			Value: map[string]any{
 				"from_address": "addssd",
+				"amount":       "462000000",
 				"chains": []any{
 					"0021",
 				},
@@ -51,7 +52,7 @@ func TestPostgresDriver_WriteTransactions(t *testing.T) {
 
 	mock.ExpectExec("INSERT into transactions").WithArgs("AF5BB3EAFF431E2E5E784D639825979FF20A779725BFE61D4521340F70C3996D0",
 		"addssd", nil, "adasdsfd", pq.StringArray([]string{"0021"}), "pos/Send", int64(0), int64(0), encodedTestStdTx,
-		[]uint8{123, 125}, "", int64(3223323), int64(10000), "upokt").
+		[]uint8{123, 125}, "", int64(3223323), int64(10000), "upokt", 462000000).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	driver := NewPostgresDriverFromSQLDBInstance(db)
@@ -67,6 +68,7 @@ func TestPostgresDriver_WriteTransactions(t *testing.T) {
 			Entropy:         3223323,
 			Fee:             10000,
 			FeeDenomination: "upokt",
+			Amount:          462000000,
 			StdTx:           testProvStdTx,
 		},
 	}
@@ -76,7 +78,7 @@ func TestPostgresDriver_WriteTransactions(t *testing.T) {
 
 	mock.ExpectExec("INSERT into transactions").WithArgs("AF5BB3EAFF431E2E5E784D639825979FF20A779725BFE61D4521340F70C3996D0",
 		"addssd", nil, "adasdsfd", pq.StringArray([]string{"0021"}), "pos/Send", int64(0), int64(0), encodedTestStdTx,
-		[]uint8{123, 125}, "", int64(3223323), int64(10000), "upokt").
+		[]uint8{123, 125}, "", int64(3223323), int64(10000), "upokt", 462000000).
 		WillReturnError(errors.New("dummy error"))
 
 	err = driver.WriteTransactions(transactionToSend)
@@ -177,6 +179,51 @@ func TestPostgresDriver_ReadTransactionsByAddress(t *testing.T) {
 	c.Empty(transactions)
 }
 
+func TestPostgresDriver_ReadTransactionsByHeight(t *testing.T) {
+	c := require.New(t)
+
+	db, mock, err := sqlmock.New()
+	c.NoError(err)
+
+	defer db.Close()
+
+	testStdTx := &stdTx{
+		StdTx: &provider.StdTx{},
+	}
+
+	encodedTestStdTx, err := testStdTx.Value()
+	c.NoError(err)
+
+	testTxResult := &txResult{
+		TxResult: &provider.TxResult{},
+	}
+
+	encodedTxResult, err := testTxResult.Value()
+	c.NoError(err)
+
+	rows := sqlmock.NewRows([]string{"id", "hash", "from_address", "to_address", "height", "stdtx", "tx_result"}).
+		AddRow(1, "ABCD", "1f32488b1db60fe528ab21e3cc26c96696be3faa", "dbcv", 21, encodedTestStdTx, encodedTxResult).
+		AddRow(2, "ABFD", "1f32488b1db60fe528ab21e3cc26c96696be3faa", "fbcv", 21, encodedTestStdTx, encodedTxResult)
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(".*").WillReturnRows(rows)
+	mock.ExpectCommit()
+
+	driver := NewPostgresDriverFromSQLDBInstance(db)
+
+	transactions, err := driver.ReadTransactionsByHeight(21, &ReadTransactionsByHeightOptions{Page: 2, PerPage: 3})
+	c.NoError(err)
+	c.Len(transactions, 2)
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(".*").WillReturnError(errors.New("dummy error"))
+	mock.ExpectCommit()
+
+	transactions, err = driver.ReadTransactionsByHeight(21, nil)
+	c.EqualError(err, "dummy error")
+	c.Empty(transactions)
+}
+
 func TestPostgresDriver_ReadTransaction(t *testing.T) {
 	c := require.New(t)
 
@@ -206,15 +253,94 @@ func TestPostgresDriver_ReadTransaction(t *testing.T) {
 
 	driver := NewPostgresDriverFromSQLDBInstance(db)
 
-	transaction, err := driver.ReadTransaction("ABCD")
+	transaction, err := driver.ReadTransactionByHash("ABCD")
 	c.NoError(err)
 	c.NotEmpty(transaction)
 
 	mock.ExpectQuery("^SELECT (.+) FROM transactions (.+)").WillReturnError(errors.New("dummy error"))
 
-	transaction, err = driver.ReadTransaction("ABCD")
+	transaction, err = driver.ReadTransactionByHash("ABCD")
 	c.EqualError(err, "dummy error")
 	c.Empty(transaction)
+}
+
+func TestPostgresDriver_GetTransactionsQuantity(t *testing.T) {
+	c := require.New(t)
+
+	db, mock, err := sqlmock.New()
+	c.NoError(err)
+
+	defer db.Close()
+
+	rows := sqlmock.NewRows([]string{"count"}).AddRow(100)
+
+	mock.ExpectQuery("^SELECT (.+) FROM transactions").WillReturnRows(rows)
+
+	driver := NewPostgresDriverFromSQLDBInstance(db)
+
+	maxHeight, err := driver.GetTransactionsQuantity()
+	c.NoError(err)
+	c.Equal(int64(100), maxHeight)
+
+	mock.ExpectQuery("^SELECT (.+) FROM transactions").WillReturnError(errors.New("dummy error"))
+
+	maxHeight, err = driver.GetTransactionsQuantity()
+	c.EqualError(err, "dummy error")
+	c.Empty(maxHeight)
+}
+
+func TestPostgresDriver_GetTransactionsQuantityByAddress(t *testing.T) {
+	c := require.New(t)
+
+	db, mock, err := sqlmock.New()
+	c.NoError(err)
+
+	defer db.Close()
+
+	rows := sqlmock.NewRows([]string{"count"}).AddRow(100)
+
+	mock.ExpectQuery("^SELECT (.+) FROM transactions").WillReturnRows(rows)
+
+	driver := NewPostgresDriverFromSQLDBInstance(db)
+
+	maxHeight, err := driver.GetTransactionsQuantityByAddress("1f32488b1db60fe528ab21e3cc26c96696be3faa")
+	c.NoError(err)
+	c.Equal(int64(100), maxHeight)
+
+	maxHeight, err = driver.GetTransactionsQuantityByAddress("1f32488b1db60fe528ab21e3cc26c96696be3fa")
+	c.Equal(ErrInvalidAddress, err)
+	c.Empty(maxHeight)
+
+	mock.ExpectQuery("^SELECT (.+) FROM transactions").WillReturnError(errors.New("dummy error"))
+
+	maxHeight, err = driver.GetTransactionsQuantityByAddress("1f32488b1db60fe528ab21e3cc26c96696be3faa")
+	c.EqualError(err, "dummy error")
+	c.Empty(maxHeight)
+}
+
+func TestPostgresDriver_GetTransactionsQuantityByHeight(t *testing.T) {
+	c := require.New(t)
+
+	db, mock, err := sqlmock.New()
+	c.NoError(err)
+
+	defer db.Close()
+
+	rows := sqlmock.NewRows([]string{"count"}).AddRow(100)
+
+	mock.ExpectQuery("^SELECT (.+) FROM transactions").WillReturnRows(rows)
+
+	driver := NewPostgresDriverFromSQLDBInstance(db)
+
+	maxHeight, err := driver.GetTransactionsQuantityByHeight(21)
+	c.NoError(err)
+	c.Equal(int64(100), maxHeight)
+
+	mock.ExpectQuery("^SELECT (.+) FROM transactions").WillReturnError(errors.New("dummy error"))
+
+	maxHeight, err = driver.GetTransactionsQuantityByHeight(21)
+	c.EqualError(err, "dummy error")
+	c.Empty(maxHeight)
 }
 
 func TestPostgresDriver_WriteBlock(t *testing.T) {
@@ -285,7 +411,7 @@ func TestPostgresDriver_ReadBlocks(t *testing.T) {
 	c.Empty(blocks)
 }
 
-func TestPostgresDriver_ReadBlock(t *testing.T) {
+func TestPostgresDriver_ReadBlockByHash(t *testing.T) {
 	c := require.New(t)
 
 	db, mock, err := sqlmock.New()
@@ -300,13 +426,39 @@ func TestPostgresDriver_ReadBlock(t *testing.T) {
 
 	driver := NewPostgresDriverFromSQLDBInstance(db)
 
-	block, err := driver.ReadBlock("ABCD")
+	block, err := driver.ReadBlockByHash("ABCD")
 	c.NoError(err)
 	c.NotEmpty(block)
 
 	mock.ExpectQuery("^SELECT (.+) FROM blocks (.+)").WillReturnError(errors.New("dummy error"))
 
-	block, err = driver.ReadBlock("ABCD")
+	block, err = driver.ReadBlockByHash("ABCD")
+	c.EqualError(err, "dummy error")
+	c.Empty(block)
+}
+
+func TestPostgresDriver_ReadBlockByHeight(t *testing.T) {
+	c := require.New(t)
+
+	db, mock, err := sqlmock.New()
+	c.NoError(err)
+
+	defer db.Close()
+
+	rows := sqlmock.NewRows([]string{"id", "hash", "height", "time", "proposer_address", "tx_count"}).
+		AddRow(1, "ABCD", 21, time.Date(1999, time.July, 21, 0, 0, 0, 0, time.Local), "ABCD", 21)
+
+	mock.ExpectQuery("^SELECT (.+) FROM blocks (.+)").WillReturnRows(rows)
+
+	driver := NewPostgresDriverFromSQLDBInstance(db)
+
+	block, err := driver.ReadBlockByHeight(21)
+	c.NoError(err)
+	c.NotEmpty(block)
+
+	mock.ExpectQuery("^SELECT (.+) FROM blocks (.+)").WillReturnError(errors.New("dummy error"))
+
+	block, err = driver.ReadBlockByHeight(21)
 	c.EqualError(err, "dummy error")
 	c.Empty(block)
 }
@@ -340,6 +492,31 @@ func TestPostgresDriver_GetMaxHeightInBlocks(t *testing.T) {
 	mock.ExpectQuery("^SELECT (.+) FROM blocks").WillReturnError(errors.New("dummy error"))
 
 	maxHeight, err = driver.GetMaxHeightInBlocks()
+	c.EqualError(err, "dummy error")
+	c.Empty(maxHeight)
+}
+
+func TestPostgresDriver_GetBlocksQuantity(t *testing.T) {
+	c := require.New(t)
+
+	db, mock, err := sqlmock.New()
+	c.NoError(err)
+
+	defer db.Close()
+
+	rows := sqlmock.NewRows([]string{"count"}).AddRow(100)
+
+	mock.ExpectQuery("^SELECT (.+) FROM blocks").WillReturnRows(rows)
+
+	driver := NewPostgresDriverFromSQLDBInstance(db)
+
+	maxHeight, err := driver.GetBlocksQuantity()
+	c.NoError(err)
+	c.Equal(int64(100), maxHeight)
+
+	mock.ExpectQuery("^SELECT (.+) FROM blocks").WillReturnError(errors.New("dummy error"))
+
+	maxHeight, err = driver.GetBlocksQuantity()
 	c.EqualError(err, "dummy error")
 	c.Empty(maxHeight)
 }

--- a/samples/query_block_txs.json
+++ b/samples/query_block_txs.json
@@ -41,6 +41,7 @@
             "value": {
               "to_address": "ABCD",
               "from_address": "CDSA",
+              "amount": "462000000",
               "chains": [
                 "0021"
               ]


### PR DESCRIPTION
- Add `ReadTransactionsByHeight` , `GetTransactionsQuantity` , `GetTransactionsQuantityByAddress` , `GetTransactionsQuantityByHeight` , `ReadBlockByHeight` , `GetBlocksQuantity` needed for new features for the frontend.

- Add `Amount` field for easier use on GraphQL API.

- Change `ReadTransaction` and `ReadBlock` to `ReadTransactionByHash` and `ReadBlockByHash` for a better naming convention.