### PR TITLE
fix: delete address validation on read account

### DIFF
--- a/postgres-driver/account.go
+++ b/postgres-driver/account.go
@@ -4,7 +4,6 @@ import (
 	"math/big"
 
 	"github.com/lib/pq"
-	"github.com/pokt-foundation/pocket-go/utils"
 	indexer "github.com/pokt-foundation/pocket-indexer-lib"
 )
 
@@ -91,10 +90,6 @@ type ReadAccountByAddressOptions struct {
 
 // ReadAccountByAddress returns an account in the database with given address
 func (d *PostgresDriver) ReadAccountByAddress(address string, options *ReadAccountByAddressOptions) (*indexer.Account, error) {
-	if !utils.ValidateAddress(address) {
-		return nil, ErrInvalidAddress
-	}
-
 	var dbAccount dbAccount
 	var height int
 

--- a/postgres-driver/account_test.go
+++ b/postgres-driver/account_test.go
@@ -65,11 +65,7 @@ func TestPostgresDriver_ReadAccountByAddress(t *testing.T) {
 
 	driver := NewPostgresDriverFromSQLDBInstance(db)
 
-	account, err := driver.ReadAccountByAddress("00353abd21ef72725b295ba5a9a5eb6082548e2", &ReadAccountByAddressOptions{Height: 21})
-	c.Equal(ErrInvalidAddress, err)
-	c.Empty(account)
-
-	account, err = driver.ReadAccountByAddress("00353abd21ef72725b295ba5a9a5eb6082548e21", &ReadAccountByAddressOptions{Height: 21})
+	account, err := driver.ReadAccountByAddress("00353abd21ef72725b295ba5a9a5eb6082548e21", &ReadAccountByAddressOptions{Height: 21})
 	c.NoError(err)
 	c.NotEmpty(account)
 


### PR DESCRIPTION
Delete address validation on read account because balances might be sent on wrong address